### PR TITLE
fix: Added 2.2 to supported framework versions

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -19,6 +19,7 @@ import * as utilities from './utilities';
 export enum FrameworkVersion {
   VERSION_1_2 = '1.2',
   VERSION_1_4 = '1.4',
+  VERSION_2_2 = '2.2',
 }
 
 /*


### PR DESCRIPTION
Just adding 2.2 to the list of supported HLF frameworks. This was released earlier this year.
Fixes #