### PR TITLE
feat: Enroll admin/user and store creds on SecretsManager

### DIFF
--- a/API.md
+++ b/API.md
@@ -46,21 +46,8 @@ new HyperledgerFabricClient(scope: HyperledgerFabricNetwork, id: string, props?:
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| [`secretsManagerVpcEndpoint`](#cdkhyperledgerfabricnetworkhyperledgerfabricclientpropertysecretsmanagervpcendpoint)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.VpcEndpoint`](#aws-cdk-lib.aws_ec2.VpcEndpoint) | VPC endpoint to access Secret Manager. |
 | [`vpc`](#cdkhyperledgerfabricnetworkhyperledgerfabricclientpropertyvpc)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.IVpc`](#aws-cdk-lib.aws_ec2.IVpc) | The client VPC that has endpoint to access the Amazon Managed Blockchain. |
-| [`vpcEndpoint`](#cdkhyperledgerfabricnetworkhyperledgerfabricclientpropertyvpcendpoint)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.VpcEndpoint`](#aws-cdk-lib.aws_ec2.VpcEndpoint) | Managed Blockchain network VPC endpoint. |
-
----
-
-##### `secretsManagerVpcEndpoint`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricClient.property.secretsManagerVpcEndpoint" id="cdkhyperledgerfabricnetworkhyperledgerfabricclientpropertysecretsmanagervpcendpoint"></a>
-
-```typescript
-public readonly secretsManagerVpcEndpoint: VpcEndpoint;
-```
-
-- *Type:* [`aws-cdk-lib.aws_ec2.VpcEndpoint`](#aws-cdk-lib.aws_ec2.VpcEndpoint)
-
-VPC endpoint to access Secret Manager.
+| [`vpcEndpoint`](#cdkhyperledgerfabricnetworkhyperledgerfabricclientpropertyvpcendpoint)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint`](#aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint) | Managed Blockchain network VPC endpoint. |
 
 ---
 
@@ -79,10 +66,10 @@ The client VPC that has endpoint to access the Amazon Managed Blockchain.
 ##### `vpcEndpoint`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricClient.property.vpcEndpoint" id="cdkhyperledgerfabricnetworkhyperledgerfabricclientpropertyvpcendpoint"></a>
 
 ```typescript
-public readonly vpcEndpoint: VpcEndpoint;
+public readonly vpcEndpoint: InterfaceVpcEndpoint;
 ```
 
-- *Type:* [`aws-cdk-lib.aws_ec2.VpcEndpoint`](#aws-cdk-lib.aws_ec2.VpcEndpoint)
+- *Type:* [`aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint`](#aws-cdk-lib.aws_ec2.InterfaceVpcEndpoint)
 
 Managed Blockchain network VPC endpoint.
 
@@ -152,6 +139,7 @@ new HyperledgerFabricNetwork(scope: Construct, id: string, props: HyperledgerFab
 | [`proposalDurationInHours`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropertyproposaldurationinhours)<span title="Required">*</span> | `number` | The duration from the time that a proposal is created until it expires. |
 | [`thresholdComparator`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropertythresholdcomparator)<span title="Required">*</span> | [`cdk-hyperledger-fabric-network.ThresholdComparator`](#cdk-hyperledger-fabric-network.ThresholdComparator) | Determines whether the yes votes must be greater than the threshold percentage or must be greater than or equal to the threhold percentage to be approved. |
 | [`thresholdPercentage`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropertythresholdpercentage)<span title="Required">*</span> | `number` | The percentage of votes among all members that must be yes for a proposal to be approved. |
+| [`users`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropertyusers)<span title="Required">*</span> | [`cdk-hyperledger-fabric-network.HyperledgerFabricUser`](#cdk-hyperledger-fabric-network.HyperledgerFabricUser)[] | List of users registered with CA. |
 | [`vpcEndpointServiceName`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropertyvpcendpointservicename)<span title="Required">*</span> | `string` | Managed Blockchain network VPC endpoint service name. |
 
 ---
@@ -381,6 +369,18 @@ public readonly thresholdPercentage: number;
 - *Type:* `number`
 
 The percentage of votes among all members that must be yes for a proposal to be approved.
+
+---
+
+##### `users`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricNetwork.property.users" id="cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropertyusers"></a>
+
+```typescript
+public readonly users: HyperledgerFabricUser[];
+```
+
+- *Type:* [`cdk-hyperledger-fabric-network.HyperledgerFabricUser`](#cdk-hyperledger-fabric-network.HyperledgerFabricUser)[]
+
+List of users registered with CA.
 
 ---
 
@@ -617,6 +617,106 @@ public readonly eventEndpoint: string;
 ---
 
 
+### HyperledgerFabricUser <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser" id="cdkhyperledgerfabricnetworkhyperledgerfabricuser"></a>
+
+Creates custom resources to register and enroll users identities with the CA using the fabric-ca-client SDK.
+
+#### Initializers <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.Initializer" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserinitializer"></a>
+
+```typescript
+import { HyperledgerFabricUser } from 'cdk-hyperledger-fabric-network'
+
+new HyperledgerFabricUser(scope: HyperledgerFabricNetwork, id: string, props: HyperledgerFabricUserProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`scope`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserparameterscope)<span title="Required">*</span> | [`cdk-hyperledger-fabric-network.HyperledgerFabricNetwork`](#cdk-hyperledger-fabric-network.HyperledgerFabricNetwork) | *No description.* |
+| [`id`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserparameterid)<span title="Required">*</span> | `string` | *No description.* |
+| [`props`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserparameterprops)<span title="Required">*</span> | [`cdk-hyperledger-fabric-network.HyperledgerFabricUserProps`](#cdk-hyperledger-fabric-network.HyperledgerFabricUserProps) | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.parameter.scope" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserparameterscope"></a>
+
+- *Type:* [`cdk-hyperledger-fabric-network.HyperledgerFabricNetwork`](#cdk-hyperledger-fabric-network.HyperledgerFabricNetwork)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.parameter.id" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserparameterid"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.parameter.props" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserparameterprops"></a>
+
+- *Type:* [`cdk-hyperledger-fabric-network.HyperledgerFabricUserProps`](#cdk-hyperledger-fabric-network.HyperledgerFabricUserProps)
+
+---
+
+
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`affiliation`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyaffiliation)<span title="Required">*</span> | `string` | User's affiliation to the member. |
+| [`userId`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyuserid)<span title="Required">*</span> | `string` | User ID registered with CA. |
+| [`userPrivateKeySecret`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyuserprivatekeysecret)<span title="Required">*</span> | [`aws-cdk-lib.aws_secretsmanager.Secret`](#aws-cdk-lib.aws_secretsmanager.Secret) | Secret for user private key. |
+| [`userSignedCertSecret`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyusersignedcertsecret)<span title="Required">*</span> | [`aws-cdk-lib.aws_secretsmanager.Secret`](#aws-cdk-lib.aws_secretsmanager.Secret) | Secret for user signed certificate. |
+
+---
+
+##### `affiliation`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.property.affiliation" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyaffiliation"></a>
+
+```typescript
+public readonly affiliation: string;
+```
+
+- *Type:* `string`
+
+User's affiliation to the member.
+
+---
+
+##### `userId`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.property.userId" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyuserid"></a>
+
+```typescript
+public readonly userId: string;
+```
+
+- *Type:* `string`
+
+User ID registered with CA.
+
+---
+
+##### `userPrivateKeySecret`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.property.userPrivateKeySecret" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyuserprivatekeysecret"></a>
+
+```typescript
+public readonly userPrivateKeySecret: Secret;
+```
+
+- *Type:* [`aws-cdk-lib.aws_secretsmanager.Secret`](#aws-cdk-lib.aws_secretsmanager.Secret)
+
+Secret for user private key.
+
+---
+
+##### `userSignedCertSecret`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUser.property.userSignedCertSecret" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserpropertyusersignedcertsecret"></a>
+
+```typescript
+public readonly userSignedCertSecret: Secret;
+```
+
+- *Type:* [`aws-cdk-lib.aws_secretsmanager.Secret`](#aws-cdk-lib.aws_secretsmanager.Secret)
+
+Secret for user signed certificate.
+
+---
+
+
 ## Structs <a name="Structs" id="structs"></a>
 
 ### HyperledgerFabricClientProps <a name="cdk-hyperledger-fabric-network.HyperledgerFabricClientProps" id="cdkhyperledgerfabricnetworkhyperledgerfabricclientprops"></a>
@@ -681,6 +781,7 @@ const hyperledgerFabricNetworkProps: HyperledgerFabricNetworkProps = { ... }
 | [`proposalDurationInHours`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropspropertyproposaldurationinhours) | `number` | The duration from the time that a proposal is created until it expires. |
 | [`thresholdComparator`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropspropertythresholdcomparator) | [`cdk-hyperledger-fabric-network.ThresholdComparator`](#cdk-hyperledger-fabric-network.ThresholdComparator) | Determines whether the yes votes must be greater than the threshold percentage or must be greater than or equal to the threhold percentage to be approved. |
 | [`thresholdPercentage`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropspropertythresholdpercentage) | `number` | The percentage of votes among all members that must be yes for a proposal to be approved. |
+| [`users`](#cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropspropertyusers) | [`cdk-hyperledger-fabric-network.HyperledgerFabricUserProps`](#cdk-hyperledger-fabric-network.HyperledgerFabricUserProps)[] | List of users to register with Fabric CA. |
 
 ---
 
@@ -838,6 +939,18 @@ The percentage of votes among all members that must be yes for a proposal to be 
 
 ---
 
+##### `users`<sup>Optional</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricNetworkProps.property.users" id="cdkhyperledgerfabricnetworkhyperledgerfabricnetworkpropspropertyusers"></a>
+
+```typescript
+public readonly users: HyperledgerFabricUserProps[];
+```
+
+- *Type:* [`cdk-hyperledger-fabric-network.HyperledgerFabricUserProps`](#cdk-hyperledger-fabric-network.HyperledgerFabricUserProps)[]
+
+List of users to register with Fabric CA.
+
+---
+
 ### HyperledgerFabricNodeProps <a name="cdk-hyperledger-fabric-network.HyperledgerFabricNodeProps" id="cdkhyperledgerfabricnetworkhyperledgerfabricnodeprops"></a>
 
 Construct properties for `HyperledgerFabricNode`.
@@ -910,6 +1023,53 @@ public readonly instanceType: InstanceType;
 - *Default:* BURSTABLE3_SMALL
 
 The Amazon Managed Blockchain instance type for the node.
+
+---
+
+### HyperledgerFabricUserProps <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUserProps" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserprops"></a>
+
+Construct properties for `HyperledgerFabricUser`.
+
+#### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
+
+```typescript
+import { HyperledgerFabricUserProps } from 'cdk-hyperledger-fabric-network'
+
+const hyperledgerFabricUserProps: HyperledgerFabricUserProps = { ... }
+```
+
+#### Properties <a name="Properties" id="properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| [`affilitation`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserpropspropertyaffilitation)<span title="Required">*</span> | `string` | User's affiliation to the member. |
+| [`userId`](#cdkhyperledgerfabricnetworkhyperledgerfabricuserpropspropertyuserid)<span title="Required">*</span> | `string` | User ID to register with CA. |
+
+---
+
+##### `affilitation`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUserProps.property.affilitation" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserpropspropertyaffilitation"></a>
+
+```typescript
+public readonly affilitation: string;
+```
+
+- *Type:* `string`
+
+User's affiliation to the member.
+
+Should be hierarchical with member name as root(`MemberName.Dept1`).
+
+---
+
+##### `userId`<sup>Required</sup> <a name="cdk-hyperledger-fabric-network.HyperledgerFabricUserProps.property.userId" id="cdkhyperledgerfabricnetworkhyperledgerfabricuserpropspropertyuserid"></a>
+
+```typescript
+public readonly userId: string;
+```
+
+- *Type:* `string`
+
+User ID to register with CA.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ out a member and its nodes, but the following enhanced functionality
 is planned for future releases:
 
 *  Add support for Java and .NET
-*  Enroll users, storing their credentials in Secrets Manager
 *  Create channels on nodes
 *  Instantiate chaincode on nodes
 
@@ -84,6 +83,10 @@ new HyperledgerFabricNetwork(this, 'Example', {
       availabilityZone: 'us-east-1b',
       instanceType: hyperledger.InstanceType.STANDARD5_LARGE,
     },
+  ],
+  users: [
+    { userId: 'AppUser1', affilitation: 'MyMember' },
+    { userId: 'AppUser2', affilitation: 'MyMember.department1' },
   ],
 });
 ```

--- a/lambdas/fabric/enroll-admin.js
+++ b/lambdas/fabric/enroll-admin.js
@@ -1,0 +1,43 @@
+const FabricCAClient = require('fabric-ca-client');
+const utilities = require('./utilities');
+
+// Extract environment variables
+const adminPasswordArn = process.env.ADMIN_PASSWORD_ARN;
+const caEndpoint = process.env.CA_ENDPOINT;
+const privateKeyArn = process.env.PRIVATE_KEY_ARN;
+const signedCertArn = process.env.SIGNED_CERT_ARN;
+const tlsCertBucket = process.env.TLS_CERT_BUCKET;
+const tlsCertKey = process.env.TLS_CERT_KEY; 
+
+const caUrl = `https://${caEndpoint}`;
+const caName = utilities.getCaName(caEndpoint);
+
+
+exports.handler = async function (event) {
+    const requestType = event.RequestType;
+
+    // Enroll the admin only on Create
+    if (requestType === 'Create') 
+    {
+        try {
+
+            // Get the TLS cert from S3 bucket
+            const caTlsCert = await utilities.getS3Object(tlsCertBucket, tlsCertKey);
+            
+            // Get the admin credentials from the secrets manager
+            const adminPwd = await utilities.getSecret(adminPasswordArn);
+
+            // Create a new CA client for interacting with the CA.
+            const ca = new FabricCAClient(caUrl, { trustedRoots: caTlsCert, verify: false }, caName);
+    
+            // Enroll the admin user, and import the new identity into secret manager.
+            const enrollment = await ca.enroll({ enrollmentID: 'admin', enrollmentSecret: adminPwd });
+            await utilities.putSecret(privateKeyArn, enrollment.key.toBytes());
+            await utilities.putSecret(signedCertArn, enrollment.certificate);
+    
+            return;
+        } catch (error) { console.error(`Failed to enroll admin user "admin": ${error}`); }
+    }
+    else return;
+
+}

--- a/lambdas/fabric/package.json
+++ b/lambdas/fabric/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fabric",
+  "version": "1.0.0",
+  "description": "",
+  "main": "enroll-admin.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.53.1",
+    "@aws-sdk/client-secrets-manager": "^3.53.0",
+    "fabric-ca-client": "^2.2.11"
+  }
+}

--- a/lambdas/fabric/register-user.js
+++ b/lambdas/fabric/register-user.js
@@ -1,0 +1,73 @@
+const FabricCAClient = require('fabric-ca-client');
+const { User } = require('fabric-common');
+const utilities = require('./utilities');
+
+// Extract environment variables
+const caEndpoint = process.env.CA_ENDPOINT;
+const orgName = process.env.MEMBER_NAME;
+const privateKeyArn = process.env.PRIVATE_KEY_ARN;
+const signedCertArn = process.env.SIGNED_CERT_ARN;
+const tlsCertBucket = process.env.TLS_CERT_BUCKET;
+const tlsCertKey = process.env.TLS_CERT_KEY; 
+
+const adminId = 'admin';
+const caUrl = `https://${caEndpoint}`;
+const caName = utilities.getCaName(caEndpoint);
+const mspId = `${orgName}Msp`; 
+
+exports.handler = async function (event) {
+
+    const requestType = event.RequestType;
+    const userData = event.ResourceProperties;
+    const userId = userData.userId;
+    const affiliation = userData.affiliation;
+
+    // Register and enroll users only on Create
+    if (requestType === 'Create') 
+    {
+        try {     
+            
+            // Get the TLS cert from S3 bucket
+            const caTlsCert = await utilities.getS3Object(tlsCertBucket, tlsCertKey);
+
+            // Get the admin credentials from the secrets manager
+            const adminPrivateKey = await utilities.getSecret(privateKeyArn);
+            const adminSignedCert = await utilities.getSecret(signedCertArn);
+
+            // Create a new CA client for interacting with the CA.
+            const ca = new FabricCAClient(caUrl, { trustedRoots: caTlsCert, verify: false }, caName);
+
+            // Create User object for the Admin. Password argument on createUser method 
+            // is not really used in creating the SignedIdentity, so defaulting it to empty string
+            const adminUser = User.createUser(adminId, '', mspId, adminSignedCert, adminPrivateKey);
+
+            // Check if user is already registered; return if exist
+            const identityService = ca.newIdentityService();
+            const identityObject = await identityService.getAll(adminUser);
+            const userResult = identityObject.result;
+            if (userResult.identities && userResult.identities.find(e => e.id === userId)) {
+                console.log(`${userId} already exist.`);
+                return;
+            }
+
+            // Admin user has the org(member) as the root affiliation by default. 
+            // If other affiliation is requested check for existence and add if not exist.
+            if (affiliation !== orgName) {
+                const affObject = ca.newAffiliationService()
+                const affRequest = await affObject.getAll(adminUser);
+                const affResult = affRequest.result;
+                if (!affResult.affiliations || !affResult.affiliations.find(e => e.name === affiliation)) await affObject.create({name: affiliation}, adminUser);
+            }
+
+            // Register and enroll the user as client, and import the new identity into secret manager.
+            const userSecret = await ca.register({ enrollmentID: userId, role: 'client', affiliation}, adminUser);
+            const userEnroll = await ca.enroll({ enrollmentID: userId, enrollmentSecret: userSecret});
+            await utilities.putSecret(userData.passwordArn, userSecret);
+            await utilities.putSecret(userData.privateKeyArn, userEnroll.key.toBytes());
+            await utilities.putSecret(userData.signedCertArn, userEnroll.certificate); 
+
+            return;
+        } catch (error) { console.error(`Failed to enroll user ${userId}: ${error}`); }
+    }
+    else return;
+}

--- a/lambdas/fabric/utilities.js
+++ b/lambdas/fabric/utilities.js
@@ -1,0 +1,41 @@
+const { GetObjectCommand, S3Client } = require('@aws-sdk/client-s3');
+const { GetSecretValueCommand, PutSecretValueCommand, SecretsManagerClient, } = require('@aws-sdk/client-secrets-manager');
+
+const s3Client = new S3Client();
+const smClient = new SecretsManagerClient();
+
+// Extracts CA Name from a CA Endpoint
+function getCaName(caEndpoint) {
+    const caName = caEndpoint.split('.')[1].split('-');
+    caName[1] = caName[1].toUpperCase();
+    return caName.join('-');
+}
+
+// Retrieve object from S3 bucket
+async function getS3Object(bucketName, key) {    
+    const objectData = await s3Client.send(new GetObjectCommand({Bucket: bucketName, Key: key}));
+    return streamToString(objectData.Body);
+}
+
+// Retrieve secret from secret manager
+async function getSecret(secretArn) {
+    const secretData = await smClient.send( new GetSecretValueCommand({ SecretId: secretArn }));
+    return secretData.SecretString;
+}
+
+// Stores secret to secret manager
+async function putSecret(secretArn, secret) {    
+    return smClient.send(new PutSecretValueCommand({ SecretId: secretArn, SecretString: secret}));;
+}
+
+// Converts a ReadableStream to a string.
+async function streamToString(stream) {
+    stream.setEncoding('utf8');
+    let data = '';
+    for await (const chunk of stream) {
+        data += chunk;
+    }
+    return data;
+}  
+  
+  module.exports = { getCaName, getS3Object, getSecret, putSecret };

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,14 +34,9 @@ export class HyperledgerFabricClient extends constructs.Construct {
   public readonly vpc: ec2.IVpc;
 
   /**
-   * VPC endpoint to access Secret Manager
-   */
-  public readonly secretsManagerVpcEndpoint: ec2.VpcEndpoint;
-
-  /**
    * Managed Blockchain network VPC endpoint
    */
-  public readonly vpcEndpoint: ec2.VpcEndpoint;
+  public readonly vpcEndpoint: ec2.InterfaceVpcEndpoint;
 
   constructor(scope: network.HyperledgerFabricNetwork, id: string, props?: HyperledgerFabricClientProps) {
     super(scope, id);
@@ -59,10 +54,13 @@ export class HyperledgerFabricClient extends constructs.Construct {
 
     // Add a VPC endpoint to access the Managed Blockchain
     const vpcService = new ec2.InterfaceVpcEndpointService( vpcEndpointServiceName );
-    this.vpcEndpoint = this.vpc.addInterfaceEndpoint('LedgerEndpoint', { service: vpcService, open: false });
+    this.vpcEndpoint = this.vpc.addInterfaceEndpoint('LedgerEndpoint', { service: vpcService, open: false, privateDnsEnabled: true });
 
     // Add VPC endpoint to access the Secrets Manager
-    this.secretsManagerVpcEndpoint = this.vpc.addInterfaceEndpoint('SecretsManagerEndpoint', { service: ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER });
+    this.vpc.addInterfaceEndpoint('SecretsManagerEndpoint', { service: ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER });
+
+    // Add VPC endpoint to access the S3
+    this.vpc.addGatewayEndpoint('S3Endpoint', { service: ec2.GatewayVpcEndpointAwsService.S3 });
 
   }
 

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as customresources from 'aws-cdk-lib/custom-resources';
+import * as constructs from 'constructs';
+
+import * as network from './network';
+import * as utilities from './utilities';
+
+/**
+ * Creates custom resources to enroll admin and register user
+ * identities with the CA using the fabric-ca-client SDK.
+ * Admin identity is enrolled by default. User identities are
+ * registered and enrolled, if provided.
+ */
+export class HyperledgerFabricIdentity extends constructs.Construct {
+
+  /**
+   * Role for custom resource lambda to assume
+   */
+  public static customRole: iam.Role;
+
+  /**
+   * Custom provider to register user identity
+   */
+  public static userProvider: customresources.Provider;
+
+  /**
+   * Custom provider to enroll admin identity
+   */
+  public readonly adminProvider: customresources.Provider;
+
+
+  constructor(scope: network.HyperledgerFabricNetwork, id: string) {
+    super(scope, id);
+
+    // Collect metadata on the stack
+    const partition = cdk.Stack.of(this).partition;
+    const region = cdk.Stack.of(this).region;
+
+    // Retrieve the S3 Bucket and key that contains the TLS cert file
+    const tlsBucketData = utilities.getTlsBucket(region);
+
+    const adminPasswordArn = scope.adminPasswordSecret.secretArn;
+    const adminPrivateKeyArn = scope.adminPrivateKeySecret.secretArn;
+    const adminSignedCertArn = scope.adminSignedCertSecret.secretArn;
+    const caEndpoint = scope.caEndpoint;
+    const client = scope.client;
+    const memberName = scope.memberName;
+
+    // Role for the custom resource lambda functions
+    const customResourceRole = new iam.Role(this, 'CustomResourceRole', { assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com') });
+
+    // Policies for the custom resource lambda to enroll and register users
+    customResourceRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'));
+    customResourceRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'));
+    customResourceRole.addToPolicy( new iam.PolicyStatement({
+      actions: ['s3:GetObject', 'secretsmanager:CreateSecret', 'secretsmanager:GetSecretValue', 'secretsmanager:PutSecretValue'],
+      resources: [
+        `arn:${partition}:s3:::${tlsBucketData.bucketName}/*`,
+        adminPasswordArn,
+        adminPrivateKeyArn,
+        adminSignedCertArn,
+      ],
+    }));
+
+    // Lambda function to enroll the admin and import credentials to secrets manager
+    const adminFunction = new lambda.Function(this, 'AdminFunction', {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'enroll-admin.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambdas/fabric')),
+      environment: {
+        ADMIN_PASSWORD_ARN: adminPasswordArn,
+        CA_ENDPOINT: caEndpoint,
+        PRIVATE_KEY_ARN: adminPrivateKeyArn,
+        SIGNED_CERT_ARN: adminSignedCertArn,
+        TLS_CERT_BUCKET: tlsBucketData.bucketName,
+        TLS_CERT_KEY: tlsBucketData.key,
+      },
+      role: customResourceRole,
+      vpc: client.vpc,
+      vpcSubnets: client.vpc.selectSubnets(),
+      timeout: cdk.Duration.minutes(1),
+    });
+
+    // Port range to access the Network
+    const ledgerPortRange = ec2.Port.tcpRange(utilities.STARTING_PORT, utilities.ENDING_PORT);
+
+    // Add access to the lambda for the Network ports
+    client.vpcEndpoint.connections.allowFrom(adminFunction, ledgerPortRange);
+
+    // Custom Resource provider
+    this.adminProvider = new customresources.Provider(this, 'AdminProvider', {
+      onEventHandler: adminFunction,
+      logRetention: logs.RetentionDays.ONE_DAY,
+    });
+
+    // Lambda function to register and enroll users and
+    // import credentials to secrets manager
+    const userFunction = new lambda.Function(scope, 'UserFunction', {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      handler: 'register-user.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambdas/fabric')),
+      environment: {
+        CA_ENDPOINT: caEndpoint,
+        MEMBER_NAME: memberName,
+        PRIVATE_KEY_ARN: adminPrivateKeyArn,
+        SIGNED_CERT_ARN: adminSignedCertArn,
+        TLS_CERT_BUCKET: tlsBucketData.bucketName,
+        TLS_CERT_KEY: tlsBucketData.key,
+      },
+      role: customResourceRole,
+      vpc: client.vpc,
+      vpcSubnets: client.vpc.selectSubnets(),
+      timeout: cdk.Duration.minutes(1),
+    });
+
+    // Add access to the lambda for the Network ports
+    scope.client.vpcEndpoint.connections.allowFrom(userFunction, ledgerPortRange);
+
+    // Custom Resource provider
+    HyperledgerFabricIdentity.userProvider = new customresources.Provider(scope, 'UserProvider', {
+      onEventHandler: userFunction,
+      logRetention: logs.RetentionDays.ONE_DAY,
+    });
+
+    // Populate the custom role static variable
+    HyperledgerFabricIdentity.customRole = customResourceRole;
+
+  }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@
 export * from './network';
 export * from './node';
 export * from './client';
+export * from './user';
 
 export { SUPPORTED_REGIONS, SUPPORTED_AVAILABILITY_ZONES } from './utilities';

--- a/src/network.ts
+++ b/src/network.ts
@@ -9,7 +9,9 @@ import * as customresources from 'aws-cdk-lib/custom-resources';
 import * as constructs from 'constructs';
 
 import * as client from './client';
+import * as identity from './identity';
 import * as node from './node';
+import * as user from './user';
 import * as utilities from './utilities';
 
 
@@ -121,6 +123,11 @@ export interface HyperledgerFabricNetworkProps {
    */
   readonly client?: client.HyperledgerFabricClientProps;
 
+  /**
+   * List of users to register with Fabric CA
+   */
+  readonly users?: Array<user.HyperledgerFabricUserProps>;
+
 }
 
 
@@ -230,6 +237,11 @@ export class HyperledgerFabricNetwork extends constructs.Construct {
    */
   public readonly client: client.HyperledgerFabricClient;
 
+  /**
+   * List of users registered with CA
+   */
+  public readonly users: Array<user.HyperledgerFabricUser>;
+
 
   constructor(scope: constructs.Construct, id: string, props: HyperledgerFabricNetworkProps) {
 
@@ -251,6 +263,7 @@ export class HyperledgerFabricNetwork extends constructs.Construct {
     this.thresholdPercentage = props.thresholdPercentage ?? 50;
     this.thresholdComparator = props.thresholdComparator ?? ThresholdComparator.GREATER_THAN;
     this.enableCaLogging = props.enableCaLogging ?? true;
+    this.users = [];
 
     // Ensure the parameters captured above are valid, so we don't
     // need to wait until deployment time to discover an error
@@ -272,6 +285,14 @@ export class HyperledgerFabricNetwork extends constructs.Construct {
     }
     if (!utilities.validateInteger(this.thresholdPercentage, 0, 100)) {
       throw new Error('Voting policy threshold percentage must be between 0 and 100.');
+    }
+
+    // Ensure the user affiliation includes the member name, if the user
+    // list for registration is provided
+    if (props.users) {
+      props.users.forEach(e => {
+        if (!e.affilitation.startsWith(this.memberName)) throw new Error('User affiliation is invalid. Affiliation should start with Member name');
+      });
     }
 
     // Per the Managed Blockchain documentation, the admin password must be at least eight
@@ -404,8 +425,16 @@ export class HyperledgerFabricNetwork extends constructs.Construct {
     }
 
     // Build out the client VPC construct
-    this.client = new client.HyperledgerFabricClient(this, 'Client', props.client);
+    this.client = new client.HyperledgerFabricClient(this, 'LedgerClient', props.client);
 
+    // Build out all the custom resources to register and enroll identities to CA
+    const identityResources = new identity.HyperledgerFabricIdentity(this, 'Identity');
+
+    // Enroll admin and store the credentials on the secrets manager
+    new cdk.CustomResource(this, 'AdminCustomResource', { serviceToken: identityResources.adminProvider.serviceToken });
+
+    // Register and enroll users, if provided
+    if (props.users) this.users = Array.from(props.users.entries()).map(e => new user.HyperledgerFabricUser(this, `User${e[0]}`, e[1]));
   }
 
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as constructs from 'constructs';
+
+import * as identity from './identity';
+import * as network from './network';
+
+/**
+ * Construct properties for `HyperledgerFabricUser`
+ */
+export interface HyperledgerFabricUserProps {
+
+  /**
+   * User's affiliation to the member.
+   * Should be hierarchical with member name as root(`MemberName.Dept1`).
+   */
+  readonly affilitation: string;
+
+  /**
+   * User ID to register with CA
+   */
+  readonly userId: string;
+
+}
+
+/**
+ * Creates custom resources to register and enroll users identities
+ * with the CA using the fabric-ca-client SDK
+ */
+export class HyperledgerFabricUser extends constructs.Construct {
+
+  /**
+   * User ID registered with CA
+   */
+  public readonly userId: string;
+
+  /**
+   * User's affiliation to the member
+   */
+  public readonly affiliation: string;
+
+  /**
+   * Secret for user signed certificate
+   */
+  public readonly userSignedCertSecret: secretsmanager.Secret;
+
+  /**
+   * Secret for user private key
+   */
+  public readonly userPrivateKeySecret: secretsmanager.Secret;
+
+
+  constructor(scope: network.HyperledgerFabricNetwork, id: string, props: HyperledgerFabricUserProps) {
+    super(scope, id);
+
+    // Populate instance variables from input properties
+    this.userId = props.userId;
+    this.affiliation = props.affilitation;
+
+    // Get the custom resources from Identity Resources class
+    const customResourceRole = identity.HyperledgerFabricIdentity.customRole;
+    const registerProvider = identity.HyperledgerFabricIdentity.userProvider;
+
+    // Ensure the user affiliation includes the member name
+    if (!this.affiliation.startsWith(scope.memberName)) throw new Error('User affiliation is invalid. Affiliation should start with Member name');
+
+    // The user credentials will be stored in these secrets
+    const userPasswordSecret = new secretsmanager.Secret(this, `${this.userId}-Password`);
+    this.userPrivateKeySecret = new secretsmanager.Secret(this, `${this.userId}-PrivateKey`);
+    this.userSignedCertSecret = new secretsmanager.Secret(this, `${this.userId}-SignedCert`);
+
+    // Add secrets arn to the custom role
+    customResourceRole.addToPolicy( new iam.PolicyStatement({
+      actions: ['secretsmanager:PutSecretValue'],
+      resources: [
+        userPasswordSecret.secretArn,
+        this.userPrivateKeySecret.secretArn,
+        this.userSignedCertSecret.secretArn,
+      ],
+    }));
+
+    const userProp = {
+      userId: this.userId,
+      affiliation: this.affiliation,
+      passwordArn: userPasswordSecret.secretArn,
+      privateKeyArn: this.userPrivateKeySecret.secretArn,
+      signedCertArn: this.userSignedCertSecret.secretArn,
+    };
+
+    // Custom resource to enroll the admin identity using fabric client SDK
+    new cdk.CustomResource(this, `${this.userId}Resource`, { serviceToken: registerProvider.serviceToken, properties: userProp });
+
+  }
+
+}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -55,6 +55,22 @@ export const SUPPORTED_AVAILABILITY_ZONES: Record<string, Array<string>> = {
   ],
 };
 
+/*
+ * Starting port of the Network port range
+ */
+export const STARTING_PORT = 30001;
+
+/*
+ * Ending port of the Network port range
+ */
+export const ENDING_PORT = 30004;
+
+/*
+ * Returns the S3 Bucket and key that contains the TLS cert file
+ */
+export function getTlsBucket(region: string) {
+  return { bucketName: `${region}.managedblockchain`, key: 'etc/managedblockchain-tls-chain.pem' };
+}
 
 /*
  * Throw an error if provided region is not in the supported list

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -33,11 +33,10 @@ describe('HyperledgerFabricClient', () => {
     });
     template.resourceCountIs('AWS::EC2::FlowLog', 1);
     template.resourceCountIs('AWS::Logs::LogGroup', 1);
-    template.resourceCountIs('AWS::EC2::VPCEndpoint', 2);
+    template.resourceCountIs('AWS::EC2::VPCEndpoint', 3);
 
     expect(network.client.vpc.vpcId).toMatch(TOKEN_REGEXP);
     expect(network.client.vpcEndpoint.vpcEndpointId).toMatch(TOKEN_REGEXP);
-    expect(network.client.secretsManagerVpcEndpoint.vpcEndpointId).toMatch(TOKEN_REGEXP);
   });
 
   test('Create endpoints on existing a client network ', () => {
@@ -65,11 +64,10 @@ describe('HyperledgerFabricClient', () => {
     });
     template.resourceCountIs('AWS::EC2::FlowLog', 1);
     template.resourceCountIs('AWS::Logs::LogGroup', 1);
-    template.resourceCountIs('AWS::EC2::VPCEndpoint', 2);
+    template.resourceCountIs('AWS::EC2::VPCEndpoint', 3);
 
     expect(network.client.vpc.vpcId).toMatch(TOKEN_REGEXP);
     expect(network.client.vpcEndpoint.vpcEndpointId).toMatch(TOKEN_REGEXP);
-    expect(network.client.secretsManagerVpcEndpoint.vpcEndpointId).toMatch(TOKEN_REGEXP);
   });
 
 });

--- a/test/network.test.ts
+++ b/test/network.test.ts
@@ -69,6 +69,7 @@ describe('HyperledgerFabricNetwork', () => {
     expect(network.adminPrivateKeySecret).toBeInstanceOf(secretsmanager.Secret);
     expect(network.adminSignedCertSecret).toBeInstanceOf(secretsmanager.Secret);
     expect(network.enableCaLogging).toBe(true);
+    expect(network.users.length).toBe(0);
   });
 
   test('Create a network with custom descriptions', () => {
@@ -338,6 +339,35 @@ describe('HyperledgerFabricNetwork', () => {
     expect(thresholdTooSmall).toThrow(Error);
     expect(thresholdTooLarge).toThrow(Error);
     expect(thresholdNotInteger).toThrow(Error);
+  });
+
+  test('Fail to create a network with invalid user affiliation', () => {
+    const invalidAffiliation = () => {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack', DEFAULT_ENV);
+      new hyperledger.HyperledgerFabricNetwork(stack, 'TestHyperledgerFabricNetwork', {
+        networkName: 'TestNetwork',
+        memberName: 'TestMember',
+        users: [
+          { userId: 'TestUser', affilitation: 'department1' },
+        ],
+      });
+    };
+    expect(invalidAffiliation).toThrow(Error);
+  });
+
+  test('Create network with user properties', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TestStack', DEFAULT_ENV);
+    const network = new hyperledger.HyperledgerFabricNetwork(stack, 'TestHyperledgerFabricNetwork', {
+      networkName: 'TestNetwork',
+      memberName: 'TestMember',
+      users: [
+        { userId: 'TestUser', affilitation: 'TestMember.department1' },
+      ],
+    });
+
+    expect(network.users.length).toBe(1);
   });
 
   test('Create network with CA Logging disabled', () => {

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import * as cdk from 'aws-cdk-lib';
+import * as assertions from 'aws-cdk-lib/assertions';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+
+import * as hyperledger from '../src';
+
+const DEFAULT_ENV = { env: { region: 'us-east-1' } };
+
+describe('HyperledgerFabricUser', () => {
+
+  test('Register user identity from network', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TestStack', DEFAULT_ENV);
+    const network = new hyperledger.HyperledgerFabricNetwork(stack, 'TestHyperledgerFabricNetwork', {
+      networkName: 'TestNetwork',
+      memberName: 'TestMember',
+      users: [
+        { userId: 'TestUser', affilitation: 'TestMember.department1' },
+      ],
+    });
+
+    expect(network.users.length).toBe(1);
+
+    const template = assertions.Template.fromStack(stack);
+    template.hasResource('AWS::Lambda::Function', {
+      Properties: {
+        Environment: {
+          Variables: {
+            TLS_CERT_BUCKET: 'us-east-1.managedblockchain',
+            TLS_CERT_KEY: 'etc/managedblockchain-tls-chain.pem',
+          },
+        },
+        Handler: 'register-user.handler',
+        Runtime: 'nodejs14.x',
+      },
+    });
+  });
+
+  test('Register user identity separate from network', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TestStack', DEFAULT_ENV);
+    const network = new hyperledger.HyperledgerFabricNetwork(stack, 'TestHyperledgerFabricNetwork', {
+      networkName: 'TestNetwork',
+      memberName: 'TestMember',
+    });
+
+    new hyperledger.HyperledgerFabricUser(network, 'TestHyperledgerFabricUser', {
+      userId: 'TestUser',
+      affilitation: 'TestMember',
+    });
+
+    const template = assertions.Template.fromStack(stack);
+    template.hasResource('AWS::Lambda::Function', {
+      Properties: {
+        Environment: {
+          Variables: {
+            TLS_CERT_BUCKET: 'us-east-1.managedblockchain',
+            TLS_CERT_KEY: 'etc/managedblockchain-tls-chain.pem',
+          },
+        },
+        Handler: 'register-user.handler',
+        Runtime: 'nodejs14.x',
+      },
+    });
+  });
+
+  test('Register user identity from network and separately', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TestStack', DEFAULT_ENV);
+    const network = new hyperledger.HyperledgerFabricNetwork(stack, 'TestHyperledgerFabricNetwork', {
+      networkName: 'TestNetwork',
+      memberName: 'TestMember',
+      users: [
+        { userId: 'TestUser1', affilitation: 'TestMember.department1' },
+      ],
+    });
+
+    const user = new hyperledger.HyperledgerFabricUser(network, 'TestHyperledgerFabricUser', {
+      userId: 'TestUser2',
+      affilitation: 'TestMember',
+    });
+
+    expect(network.users.length).toBe(1);
+    expect(user.userPrivateKeySecret).toBeInstanceOf(secretsmanager.Secret);
+    expect(user.userSignedCertSecret).toBeInstanceOf(secretsmanager.Secret);
+
+    const template = assertions.Template.fromStack(stack);
+    template.hasResource('AWS::Lambda::Function', {
+      Properties: {
+        Environment: {
+          Variables: {
+            TLS_CERT_BUCKET: 'us-east-1.managedblockchain',
+            TLS_CERT_KEY: 'etc/managedblockchain-tls-chain.pem',
+          },
+        },
+        Handler: 'register-user.handler',
+        Runtime: 'nodejs14.x',
+      },
+    });
+  });
+
+  test('Fail to register user identity separate from network when affiliation is invalid', () => {
+    const invalidAffiliation = () => {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack', DEFAULT_ENV);
+      const network = new hyperledger.HyperledgerFabricNetwork(stack, 'TestHyperledgerFabricNetwork', {
+        networkName: 'TestNetwork',
+        memberName: 'TestMember',
+      });
+
+      new hyperledger.HyperledgerFabricUser(network, 'TestHyperledgerFabricUser', {
+        userId: 'TestUser',
+        affilitation: 'Department1',
+      });
+    };
+
+    expect(invalidAffiliation).toThrow(Error);
+  });
+
+});


### PR DESCRIPTION
Feature:

    - Enroll admin using the Fabric CA Client SDK and store credentials on SecretsManager
    - Register and enroll users and store credentials on SecretsManager

Update:

    - Add S3 endpoint for accessing the TLS cert
    - Enable private DNS on the VPC endpoint
    - Remove 'register user feature' from README

